### PR TITLE
User story 2

### DIFF
--- a/app/controllers/api/v1/subscriptions_controller.rb
+++ b/app/controllers/api/v1/subscriptions_controller.rb
@@ -1,18 +1,29 @@
 class Api::V1::SubscriptionsController < ApplicationController
   rescue_from ActiveRecord::RecordNotFound, with: :record_not_found
-  before_action :parse_json, :validate_frequency
+  before_action(
+    :parse_json,
+    :validate_frequency,
+    :get_customer,
+    :get_tea,
+    only: :create
+  )
 
   def create
-    customer = Customer.find(params[:customer_id])
-    tea = Tea.find(@body[:tea_id])
-
-    subscription = Subscription.build_from_request(@body[:frequency], customer, tea)
+    subscription = Subscription.build_from_request(@body[:frequency], @customer, @tea)
     subscription.save
     render json: Api::V1::SubscriptionSerializer.show(subscription), status: 201
   end
 
+  def destroy
+    subscription = Subscription.find(params[:id])
+    subscription.status = 'cancelled'
+    subscription.save
+    render json: Api::V1::SubscriptionSerializer.show(subscription), status: 202
+  end
+
+  private
   def record_not_found
-    render json: { 'error': 'invalid customer_id or tea_id' }, status: 404
+    render json: { 'error': 'invalid id(s)' }, status: 404
   end
 
   def parse_json
@@ -23,5 +34,13 @@ class Api::V1::SubscriptionsController < ApplicationController
     if !["weekly", "biweekly", "monthly"].include?(@body[:frequency])
       render json: { 'error': 'invalid frequency' }, status: 404
     end
+  end
+
+  def get_customer
+    @customer = Customer.find(params[:customer_id])
+  end
+
+  def get_tea
+    @tea = Tea.find(@body[:tea_id])
   end
 end

--- a/app/models/subscription.rb
+++ b/app/models/subscription.rb
@@ -13,19 +13,22 @@ class Subscription < ApplicationRecord
       customer_id: customer.id,
       tea_id: tea.id,
       frequency: frequency,
+      price: get_price(frequency),
       title: "#{customer.first_name}'s #{frequency.capitalize} #{tea.title}",
       status: 'active'
     }
 
+    new(hash)
+  end
+
+  def self.get_price(frequency)
     case frequency
       when "monthly"
-        hash[:price] = 1500
+        1500
       when "biweekly"
-        hash[:price] = 800
+        800
       when "weekly"
-        hash[:price] = 500
+        500
     else; end
-
-    new(hash)
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,7 +3,7 @@ Rails.application.routes.draw do
   namespace :api do
     namespace :v1 do
       resources :customers, only: [] do
-        resources :subscriptions, only: [:create]
+        resources :subscriptions, only: [:create, :destroy]
       end
     end
   end

--- a/spec/models/subscription_spec.rb
+++ b/spec/models/subscription_spec.rb
@@ -28,5 +28,22 @@ RSpec.describe Subscription do
       expect(subscription.price).to eq 1500
       expect(subscription.id).to be_nil
     end
+
+    context '.get_price(frequency) calculates price based on frequency' do
+      it 'monthly is 1500' do
+        price = Subscription.get_price('monthly')
+        expect(price).to eq 1500
+      end
+
+      it 'biweekly is 800' do
+        price = Subscription.get_price('biweekly')
+        expect(price).to eq 800
+      end
+
+      it 'weekly is 500' do
+        price = Subscription.get_price('weekly')
+        expect(price).to eq 500
+      end
+    end
   end
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -1,4 +1,5 @@
 # This file is copied to spec/ when you run 'rails generate rspec:install'
+# :nocov:
 require 'spec_helper'
 ENV['RAILS_ENV'] ||= 'test'
 require_relative '../config/environment'
@@ -68,3 +69,4 @@ Shoulda::Matchers.configure do |config|
     with.library :rails
   end
 end
+# :nocov:

--- a/spec/requests/api/v1/customers/subscribe_to_a_tea_spec.rb
+++ b/spec/requests/api/v1/customers/subscribe_to_a_tea_spec.rb
@@ -38,7 +38,7 @@ RSpec.describe 'Subscribing a customer to a Tea' do
   end
 
   context 'sad path' do
-    it 'invalid cuystomer id returns 404' do
+    it 'invalid customer id returns 404' do
       tea = FactoryBot.create(:tea)
       post '/api/v1/customers/1000/subscriptions',
         headers: {'Content-Type': 'application/json'},
@@ -50,7 +50,7 @@ RSpec.describe 'Subscribing a customer to a Tea' do
       full_response = JSON.parse(response.body, symbolize_names: true)
 
       expect(full_response).to have_key :error
-      expect(full_response[:error]).to eq 'invalid customer_id or tea_id'
+      expect(full_response[:error]).to eq 'invalid id(s)'
     end
 
     it 'invalid tea id returns 404' do
@@ -65,7 +65,7 @@ RSpec.describe 'Subscribing a customer to a Tea' do
       full_response = JSON.parse(response.body, symbolize_names: true)
 
       expect(full_response).to have_key :error
-      expect(full_response[:error]).to eq 'invalid customer_id or tea_id'
+      expect(full_response[:error]).to eq 'invalid id(s)'
     end
 
     it 'frequency must be weekly, biweekly, or monthly' do

--- a/spec/requests/api/v1/customers/unsubscribe_from_a_tea_spec.rb
+++ b/spec/requests/api/v1/customers/unsubscribe_from_a_tea_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe 'Unsibscribing a customer from a tea' do
       delete "/api/v1/customers/#{customer.id}/subscriptions/#{subscription.id}"
 
       expect(response).to be_successful
-      expect(response).to have_http_status 204
+      expect(response).to have_http_status 202
 
       full_response = JSON.parse(response.body, symbolize_names: true)
       expect(full_response).to have_key :data
@@ -62,28 +62,7 @@ RSpec.describe 'Unsibscribing a customer from a tea' do
       
       full_response = JSON.parse(response.body, symbolize_names: true)
       expect(full_response).to have_key :error
-      expect(full_response[:error]).to eq 'invalid customer_id or subscription_id'
-    end
-
-    it 'invalid customer_id results in a 404' do
-      customer = FactoryBot.create(:customer)
-      tea = FactoryBot.create(:tea)
-      customer.subscriptions.create!(
-        tea_id: tea.id,
-        frequency: 'monthly',
-        price: 1500,
-        title: 'cool title',
-        status: 'active'
-      )
-      subscription = Subscription.all.last
-
-      delete "/api/v1/customers/1000/subscriptions/#{subscription.id}"
-      expect(response).to_not be_successful
-      expect(response).to have_http_status 404
-      
-      full_response = JSON.parse(response.body, symbolize_names: true)
-      expect(full_response).to have_key :error
-      expect(full_response[:error]).to eq 'invalid customer_id or subscription_id'
+      expect(full_response[:error]).to eq 'invalid id(s)'
     end
   end
 end

--- a/spec/requests/api/v1/customers/unsubscribe_from_a_tea_spec.rb
+++ b/spec/requests/api/v1/customers/unsubscribe_from_a_tea_spec.rb
@@ -1,0 +1,71 @@
+require 'rails_helper'
+
+RSpec.describe 'Unsibscribing a customer from a tea' do
+  context 'happy path' do
+    it 'returns JSON showing the cancelled subscription' do
+      customer = FactoryBot.create(:customer)
+      tea = FactoryBot.create(:tea)
+      customer.subscriptions.create!(tea_id: tea.id, frequency: 'monthly', price: 1500, title: 'cool title', status: 'active')
+      subscription = Subscription.all.last
+
+      delete "/api/v1/customers/#{customer.id}/subscriptions/#{subscription.id}"
+
+      expect(response).to be_successful
+      expect(response).to have_http_status 204
+
+      full_response = JSON.parse(response.body, symbolize_names: true)
+      expect(full_response).to have_key :data
+      expect(full_response[:data]).to be_a Hash
+
+      sub_data = full_response[:data]
+      expect(sub_data).to have_key :id
+      expect(sub_data[:id]).to be_a String
+      expect(sub_data).to have_key :type
+      expect(sub_data[:type]).to eq 'subscription'
+      expect(sub_data).to have_key :attributes
+      expect(sub_data[:attributes]).to be_a Hash
+
+      sub_attributes = sub_data[:attributes]
+      expect(sub_attributes).to have_key :title
+      expect(sub_attributes[:title]).to be_a String
+      expect(sub_attributes).to have_key :price
+      expect(sub_attributes[:price]).to be_an Integer
+      expect(sub_attributes).to have_key :frequency
+      expect(sub_attributes[:frequency]).to eq 'monthly'
+      expect(sub_attributes).to have_key :status
+      expect(sub_attributes[:status]).to eq 'cancelled'
+    end
+  end
+
+  context 'sad path' do
+    it 'invalid subscription_id results in a 404' do
+      customer = FactoryBot.create(:customer)
+      tea = FactoryBot.create(:tea)
+      customer.subscriptions.create!(tea_id: tea.id, frequency: 'monthly', price: 1500, title: 'cool title', status: 'active')
+      subscription = Subscription.all.last
+
+      delete "/api/v1/customers/#{customer.id}/subscriptions/1000"
+      expect(response).to_not be_successful
+      expect(response).to have_http_status 404
+      
+      full_response = JSON.parse(response.body, symbolize_names: true)
+      expect(full_response).to have_key :error
+      expect(full_response[:error]).to eq 'invalid customer_id or subscription_id'
+    end
+
+    it 'invalid customer_id results in a 404' do
+      customer = FactoryBot.create(:customer)
+      tea = FactoryBot.create(:tea)
+      customer.subscriptions.create!(tea_id: tea.id, frequency: 'monthly', price: 1500, title: 'cool title', status: 'active')
+      subscription = Subscription.all.last
+
+      delete "/api/v1/customers/1000/subscriptions/#{subscription.id}"
+      expect(response).to_not be_successful
+      expect(response).to have_http_status 404
+      
+      full_response = JSON.parse(response.body, symbolize_names: true)
+      expect(full_response).to have_key :error
+      expect(full_response[:error]).to eq 'invalid customer_id or subscription_id'
+    end
+  end
+end

--- a/spec/requests/api/v1/customers/unsubscribe_from_a_tea_spec.rb
+++ b/spec/requests/api/v1/customers/unsubscribe_from_a_tea_spec.rb
@@ -5,7 +5,13 @@ RSpec.describe 'Unsibscribing a customer from a tea' do
     it 'returns JSON showing the cancelled subscription' do
       customer = FactoryBot.create(:customer)
       tea = FactoryBot.create(:tea)
-      customer.subscriptions.create!(tea_id: tea.id, frequency: 'monthly', price: 1500, title: 'cool title', status: 'active')
+      customer.subscriptions.create!(
+        tea_id: tea.id,
+        frequency: 'monthly',
+        price: 1500,
+        title: 'cool title',
+        status: 'active'
+      )
       subscription = Subscription.all.last
 
       delete "/api/v1/customers/#{customer.id}/subscriptions/#{subscription.id}"
@@ -41,7 +47,13 @@ RSpec.describe 'Unsibscribing a customer from a tea' do
     it 'invalid subscription_id results in a 404' do
       customer = FactoryBot.create(:customer)
       tea = FactoryBot.create(:tea)
-      customer.subscriptions.create!(tea_id: tea.id, frequency: 'monthly', price: 1500, title: 'cool title', status: 'active')
+      customer.subscriptions.create!(
+        tea_id: tea.id,
+        frequency: 'monthly',
+        price: 1500,
+        title: 'cool title',
+        status: 'active'
+      )
       subscription = Subscription.all.last
 
       delete "/api/v1/customers/#{customer.id}/subscriptions/1000"
@@ -56,7 +68,13 @@ RSpec.describe 'Unsibscribing a customer from a tea' do
     it 'invalid customer_id results in a 404' do
       customer = FactoryBot.create(:customer)
       tea = FactoryBot.create(:tea)
-      customer.subscriptions.create!(tea_id: tea.id, frequency: 'monthly', price: 1500, title: 'cool title', status: 'active')
+      customer.subscriptions.create!(
+        tea_id: tea.id,
+        frequency: 'monthly',
+        price: 1500,
+        title: 'cool title',
+        status: 'active'
+      )
       subscription = Subscription.all.last
 
       delete "/api/v1/customers/1000/subscriptions/#{subscription.id}"


### PR DESCRIPTION
[Link to issue](https://github.com/B-gann21/tea_subscription/issues/9)
Tests: 
- added happy and sad path tests for the `Unsubscribe a Customer from a Tea` endpoint
- fixed a typo in `subscribe_to_a_tea_spec`

Features:
- `delete` request to `api/v1/customers/:customer_id/subscriptions/:subscription_id` changes that subscriptions status from 'active' to 'cancelled', but does not delete the record from the database. The record of the cancelled subscription is saved in the DB for use in User Story 3